### PR TITLE
Se corrige error en usuario de Medidas de protección

### DIFF
--- a/format/medidasDeProteccion/inserts/saveDatosGenerales.php
+++ b/format/medidasDeProteccion/inserts/saveDatosGenerales.php
@@ -80,7 +80,7 @@ if($idMedida == 0 && $rolUser != 4){
      SET NOCOUNT ON
        declare @insertado int
      
-       INSERT INTO medidas.medidasProteccion VALUES($data[1],0,0,0,$data[2], $fechaAcuerdo,GETDATE(), DATEPART(dw, $fechaAcuerdo), DATEPART(day, $fechaAcuerdo), DATEPART(month, $fechaAcuerdo), DATEPART(year, $fechaAcuerdo), $idEnlace, $data[10], 1, '')
+       INSERT INTO medidas.medidasProteccion VALUES($data[1],0,0,0,$data[2], $fechaAcuerdo,GETDATE(), DATEPART(dw, $fechaAcuerdo), DATEPART(day, $fechaAcuerdo), DATEPART(month, $fechaAcuerdo), DATEPART(year, $fechaAcuerdo), $idEnlace, $data[10], 1, '',null)
 
        select @insertado = @@IDENTITY
 


### PR DESCRIPTION
El usuario usersire301 obtenía error al capturar ya que fue de los primeros usuarios de la anterior versión del sistema y con las modificaciones recientes al incorporar el campo de corporaciones policiales este no le permitia guardar.